### PR TITLE
set max version for import linter to 1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-import-linter = "^1.0"
+import-linter = ">= 1.0, <= 1.3"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Lars Rinn <lars.rinn@node.energy>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 import-linter = ">= 1.0, <= 1.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Running the pre-commit hooks in the optinode-backend with version 1.4 of the import linter fails. As a workaround we set the max version of the import linter to 1.3

Source for setting a max version in a project.toml file:
https://python-poetry.org/docs/dependency-specification/#multiple-requirements

If you want to reproduce the error, make sure to run `pre-commit clean` in order to make sure to get the newest version of the import linter.

Error Message of `pre-commit run`:

```
Run import linter...........................................................Failed
- hook id: import-linter
- exit code: 1
=============
Import Linter
=============
ForbiddenRelativeImportContract.check() got an unexpected keyword argument 'verbose'
```