### PR TITLE
Match import-linter 1.4 from optinode_backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-import-linter = {version=">= 1.0, <= 1.3", extras=["toml"]}
+import-linter = {version="^1.4", extras=["toml"]}
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"


### PR DESCRIPTION
optinode_backend will update to import-linter 1.4 with https://github.com/node-energy/optinode_backend/pull/6545

We need to update the pre-commit-hooks as well so that they continue to work